### PR TITLE
tmux: mouse support options changed in 2.1

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -83,10 +83,22 @@ set -g base-index 1
 setw -g pane-base-index 1
 
 # Mouse support - set to on if you want to use the mouse.
-setw -g mode-mouse off
-set -g mouse-select-pane off
-set -g mouse-resize-pane off
-set -g mouse-select-window off
+#
+# https://github.com/tmux/tmux/issues/145
+# http://stackoverflow.com/a/33461197/117714
+# Enable Mouse support in tmux 2.1:
+set -g mouse on
+# enable scrolling outside of copy mode in 2.1:
+# enter copy mode by scrolling:
+## bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+# allow mousing to scroll when hovering over a non-selected window:
+## bind -n WheelDownPane select-pane -t= \; send-keys -M
+
+# Enable Mouse support before tmux 2.1:
+# setw -g mode-mouse off
+# set -g mouse-select-pane off
+# set -g mouse-resize-pane off
+# set -g mouse-select-window off
 
 # Set the default terminal mode to 256color mode.
 set -g default-terminal "screen-256color"


### PR DESCRIPTION
This works to enable mouse scrolling in copy mode.  

However, it seems to disable selection highlighting.  Running tmux 2.1 in iterm 2.1.4.  When I select something it gets copied (iterm copy-on-select) but then the select highlighting disappears.   Highlighting works normally with `set -g mouse off`.  Same behavior in `terminal.app` and in iterm with copy-on-select disabled.  Looks like a tmux issue.  Yep, it's #worksasdesigned:   tmux/tmux#140

I haven't tested the scroll-outside-of-copy-mode options.
