### PR TITLE
four most recent years of tmux tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+resurrect
+tmux*log
+plugins

--- a/tmux.conf
+++ b/tmux.conf
@@ -2,7 +2,6 @@
 # By remapping the `CapsLock` key to `Ctrl`,
 # you can make triggering commands more comfortable!
 set -g prefix `
-#set-option -g default-command "reattach-to-user-namespace -l zsh"
 
 # Free the original `Ctrl-b` prefix keybinding.
 unbind C-b
@@ -83,8 +82,6 @@ bind O pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 bind Escape copy-mode
 unbind P
 bind P paste-buffer
-# bind -t vi-copy 'v' begin-selection
-# bind -t vi-copy 'y' copy-selection
 
 # Changed for 2.4 (2.2?) vi-copy is replaced by copy-mode-vi
 # See:
@@ -95,17 +92,9 @@ bind-key -T copy-mode-vi 'v' send -X begin-selection
 bind-key -T copy-mode-vi 'y' send -X copy-selection
 # bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
 # bind-key -T copy-mode-vi 'y' send-keys -X copy-selection
-# copy to mac clipboard
-# This is where the magic happens
-# bind-key -T copy-mode-vi 'Y' send-keys -X copy-pipe 'reattach-to-user-namespace pbcopy'
 
 # set history size to reasonably large
 set -g history-limit 50000
-
-
-# copy to mac clipboard
-# This is where the magic happens
-# bind -t vi-copy Y copy-pipe "reattach-to-user-namespace pbcopy"
 
 
 # Setting the delay between prefix and command.

--- a/tmux.conf
+++ b/tmux.conf
@@ -142,4 +142,11 @@ set -g @plugin 'nhdaly/tmux-better-mouse-mode'
 set -g @scroll-without-changing-pane "on"
 set -g @emulate-scroll-for-no-mouse-alternate-buffer "on"
 
+set -g @plugin 'tmux-plugins/tmux-resurrect'  ## requirement for continuum
+set -g @plugin 'tmux-plugins/tmux-continuum'
+## enable restore of vim session, via vim-obsession vim plugin
+set -g @resurrect-strategy-vim 'session'
+## to enable continuum auto-store of sessions
+set -g @continuum-restore 'on'
+
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux.conf
+++ b/tmux.conf
@@ -2,6 +2,7 @@
 # By remapping the `CapsLock` key to `Ctrl`,
 # you can make triggering commands more comfortable!
 set -g prefix `
+#set-option -g default-command "reattach-to-user-namespace -l zsh"
 
 # Free the original `Ctrl-b` prefix keybinding.
 unbind C-b
@@ -9,7 +10,8 @@ unbind C-b
 ## Ensure that we can send `Ctrl-a` to other apps.
 bind '~' send-prefix
 bind ` last-window
-bind '"' choose-window -N
+bind "'" choose-tree
+bind '"' run 'tmux choose-tree -Nwf"##{==:##{session_name},#{session_name}}"'
 bind '!' split-window -h "exec htop"
 bind '/' command-prompt "split-window -h 'exec man %%'"
 
@@ -75,6 +77,8 @@ bind O pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 bind Escape copy-mode
 unbind P
 bind P paste-buffer
+# bind -t vi-copy 'v' begin-selection
+# bind -t vi-copy 'y' copy-selection
 
 # Changed for 2.4 (2.2?) vi-copy is replaced by copy-mode-vi
 # See:
@@ -91,6 +95,11 @@ bind-key -T copy-mode-vi 'y' send -X copy-selection
 
 # set history size to reasonably large
 set -g history-limit 50000
+
+
+# copy to mac clipboard
+# This is where the magic happens
+# bind -t vi-copy Y copy-pipe "reattach-to-user-namespace pbcopy"
 
 
 # Setting the delay between prefix and command.
@@ -138,7 +147,8 @@ set -g message-style fg=white,bg=black,bright,fg=colour16
 set -g window-status-format "#[fg=white,bg=colour234] #I #W "
 #
 ## Solarized color.
-source-file ~/.dotfiles/tmux/vendor/tmux-colors-solarized/tmuxcolors-dark.conf
+# source-file ~/.dotfiles/tmux/vendor/tmux-colors-solarized/tmuxcolors-dark.conf
+# source-file ~/.dotfiles/tmux/vendor/tmux-colors-solarized/tmuxcolors.conf
 
 
 # Import OS specific configuration.
@@ -159,4 +169,10 @@ set -g @resurrect-strategy-vim 'session'
 ## to enable continuum auto-store of sessions
 set -g @continuum-restore 'on'
 
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'seebi/tmux-colors-solarized'
+set -g @plugin 'tmux-plugins/tmux-battery'
+set -g @plugin 'tmux-plugins/tmux-yank'
+
+# keep as last line to run the tmux plugin manager
 run '~/.tmux/plugins/tpm/tpm'

--- a/tmux.conf
+++ b/tmux.conf
@@ -34,9 +34,15 @@ setenv -g SSH_AUTH_SOCK $HOME/.ssh/ssh_auth_sock
 ## Reload the file with Prefix r.
 bind r source-file ~/.tmux.conf \; display "Reloaded!"
 
+# new windows
+# new window with current directory
+bind C new-window -c "#{pane_current_path}"
+# change start-directory for new windows in this session
+bind M-c attach-session -c "#{pane_current_path}"
+
 # Splitting panes.
-bind | split-window -h
-bind - split-window -v
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
 bind [ select-pane -L
 bind ] select-pane -R
 
@@ -52,7 +58,7 @@ bind x kill-pane #P
 # Close window
 bind X kill-window
 
-# Moveing between windows.
+# Moving between windows.
 # Provided you've mapped your `CAPS LOCK` key to the `CTRL` key,
 # you can now move between panes without moving your hands off the home row.
 bind -r C-h select-window -t :-

--- a/tmux.conf
+++ b/tmux.conf
@@ -9,9 +9,14 @@ unbind C-b
 ## Ensure that we can send `Ctrl-a` to other apps.
 bind '~' send-prefix
 bind ` last-window
-bind '"' choose-window
+bind '"' choose-window -N
 bind '!' split-window -h "exec htop"
 bind '/' command-prompt "split-window -h 'exec man %%'"
+
+# bind 'M-/' attach-session -t . -c '#{pane_current_path}'
+bind 'M-/' attach  -c '#{pane_current_path}'
+
+bind 'C' new-window -c '#{pane_current_path}'
 
 ## zsh4lyf3
 set-option -g default-shell /usr/bin/zsh

--- a/tmux.conf
+++ b/tmux.conf
@@ -1,6 +1,6 @@
 # Setting the prefix from `C-b` to `C-a`.
 # By remapping the `CapsLock` key to `Ctrl`,
-# you can make triggering commands more comfottable!
+# you can make triggering commands more comfortable!
 set -g prefix `
 
 # Free the original `Ctrl-b` prefix keybinding.

--- a/tmux.conf
+++ b/tmux.conf
@@ -102,6 +102,19 @@ set -g base-index 1
 ## Set the base index for panes to 1 instead of 0.
 setw -g pane-base-index 1
 
+# Enable mouse for 2.2+
+#set -g mouse on
+# Disable copy on end of mouse drag
+# See: https://github.com/tmux/tmux/issues/140#issuecomment-302742783
+# Duplicate into copy-mode-vi as well as copy-mode.  Success!
+# 2.4+
+unbind -T copy-mode MouseDragEnd1Pane
+unbind -T copy-mode MouseUp1Pane
+unbind -T copy-mode-vi MouseDragEnd1Pane
+unbind -T copy-mode-vi MouseUp1Pane
+# 2.2-2.3
+# unbind -t vi-copy MouseDragEnd1Pane
+
 #
 ## Enable activity alerts.
 setw -g monitor-activity on

--- a/tmux.conf
+++ b/tmux.conf
@@ -12,6 +12,17 @@ bind ` last-window
 bind '"' choose-window
 bind '!' split-window -h "exec htop"
 bind '/' command-prompt "split-window -h 'exec man %%'"
+
+## zsh4lyf3
+set-option -g default-shell /usr/bin/zsh
+
+## Automate ssh auth handling.  See also ~/.ssh/rc
+# Remove SSH_AUTH_SOCK to disable auto-resetting of Tmux variable
+set -g update-environment "DISPLAY SSH_ASKPASS SSH_AGENT_PID \
+                           SSH_CONNECTION WINDOWID XAUTHORITY"
+# Use a symlink to look up SSH authentication
+setenv -g SSH_AUTH_SOCK $HOME/.ssh/ssh_auth_sock
+
 #
 ## Reload the file with Prefix r.
 bind r source-file ~/.tmux.conf \; display "Reloaded!"

--- a/tmux.conf
+++ b/tmux.conf
@@ -70,11 +70,19 @@ bind O pipe-pane -o "cat >>~/#W.log" \; display "Toggled logging to ~/#W.log"
 bind Escape copy-mode
 unbind P
 bind P paste-buffer
-bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
-bind-key -T copy-mode-vi 'y' send-keys -X copy-selection
+
+# Changed for 2.4 (2.2?) vi-copy is replaced by copy-mode-vi
+# See:
+#  * https://github.com/tmux/tmux/issues/592
+#  * https://github.com/tmux/tmux/commit/76d6d3641f271be1756e41494960d96714e7ee58
+#  * https://github.com/tmux/tmux/issues/592#issuecomment-255763680
+bind-key -T copy-mode-vi 'v' send -X begin-selection
+bind-key -T copy-mode-vi 'y' send -X copy-selection
+# bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
+# bind-key -T copy-mode-vi 'y' send-keys -X copy-selection
 # copy to mac clipboard
 # This is where the magic happens
-bind-key -T copy-mode-vi 'Y' send-keys -X copy-pipe 'reattach-to-user-namespace pbcopy'
+# bind-key -T copy-mode-vi 'Y' send-keys -X copy-pipe 'reattach-to-user-namespace pbcopy'
 
 # set history size to reasonably large
 set -g history-limit 50000

--- a/tmux.conf-linux
+++ b/tmux.conf-linux
@@ -1,15 +1,16 @@
 # Linux specific configuration:
 
 ## copy to clipboard
-bind -t vi-copy Y copy-pipe "xclip -sel clip -i"
+#bind -t vi-copy Y copy-pipe "xclip -sel clip -i"
+#bind-key -Tcopy-mode-vi 'Y' copy-pipe "xclip -sel clip -i"
 
 ## terminal default for linux
 set -g default-terminal "screen-256color"
 
 ## set linux specific status:
 
-set -g status-right '#[fg=white]#(hostname)@#(host `hostname` | cut -d " " -f 4)'
+#set -g status-right '#[fg=white]#(hostname)@#(host `hostname` | cut -d " " -f 4)'
 
-set -g status-left '#[fg=colour235,bg=colour252,bold] #S#[fg=colour252,bg=colour238,nobold]#[fg=colour245,bg=colour238,bold] #(whoami)#[fg=colour238,bg=colour234,nobold]'
-set -g status-right '#[fg=colour235, bg=colour252,bold]#(ifconfig eth0 | grep "inet " | cut -d" " -f12 | cut -d":" -f2 | xargs echo "Ether:")'
-set -g window-status-current-format "#[fg=colour234,bg=colour39]#[fg=colour232,bg=colour39,noreverse,bold] #I #W#[fg=colour39,bg=colour234,nobold]"
+set -g status-left '#[fg=colour235,bg=colour252,bold] 🍺  #S#[fg=colour252,bg=colour238,nobold]⮀#[fg=colour245,bg=colour238,bold] #(whoami)#[fg=colour238,bg=colour234,nobold]⮀'
+set -g status-right '#[fg=colour39, bg=colour234]⮂#[fg=colour234,bg=colour39]#(ifconfig wlp58s0 | grep "inet " | cut -d" " -f 10 | xargs echo "Wi-Fi :") #[fg=colour234,bg=colour250]#(ifconfig tun0 | grep "inet " | cut -d" " -f 10 | xargs echo "VPN :" )'
+set -g window-status-current-format "#[fg=colour234,bg=colour39]⮀#[fg=colour232,bg=colour39,noreverse,bold] #I ⮁ #W#[fg=colour39,bg=colour234,nobold]⮀"


### PR DESCRIPTION
* tpm plugins
    * remember `I` to install and `U` to upgrade tmux plugins. 
    * resurrect + continuum to save and restore state of tmux splits automatically
    * vim-obsession to restore vim sessions when restoring tmux!
    * sensible: sensible tmux defaults
    * battery: display battery info numerically or as colors in status bar
    * yank: should integrate with system clipboard and remove need for manually wrapping on OSX.
    * solarized: so we can remove the solarized submodule
    
* maintain and update working directory when opening new panes, splits.  Bindings:  `C`, `|`, `-`, `M-c`, `M-\`
* choose-window emulated with choose-tree.  Bindings: `'` and `"`
* tweaks to change status settings and disable copy-pipe for linux
* Experimental: tmux mouse support
* vi-copy replaced by copy-mode-vi
* SSH_AUTH_SOCK handling
* zsh as default shell
* fix typos in comments